### PR TITLE
Changed the base image to alpine to decrease image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:18.09.5-dind AS docker
 FROM docker/compose:1.23.2 AS docker-compose
-FROM python:3.7.2-stretch
+FROM python:3.7.3-alpine3.10
 
 COPY --from=docker-compose /usr/local/bin/docker-compose /usr/local/bin/docker-compose
 COPY --from=docker /usr/local/bin/docker /usr/local/bin/docker


### PR DESCRIPTION
The Docker image size is a lot smaller when using Alpine as base image.
![Screenshot 2019-07-15 at 17 27 35](https://user-images.githubusercontent.com/6033289/61228346-64029f00-a726-11e9-9107-037bf3969a60.png)
